### PR TITLE
fix: change import to type-only import

### DIFF
--- a/app/middleware/container_bindings_middleware.ts
+++ b/app/middleware/container_bindings_middleware.ts
@@ -1,6 +1,6 @@
 import { Logger } from '@adonisjs/core/logger'
 import { HttpContext } from '@adonisjs/core/http'
-import { NextFn } from '@adonisjs/core/types/http'
+import type { NextFn } from '@adonisjs/core/types/http'
 
 /**
  * The container bindings middleware binds classes to their request


### PR DESCRIPTION
### 🔗 Linked issue

#5 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Replaced `import { NextFn } from '@adonisjs/core/types/http'` with `import type { NextFn } from '@adonisjs/core/types/http'` to ensure that the import is used only for type checking.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
